### PR TITLE
ethereum mainnet contract config update

### DIFF
--- a/networks.json
+++ b/networks.json
@@ -1,8 +1,8 @@
 {
-  "sepolia": {
+  "mainnet": {
     "wXTMBridge": {
-      "address": "0x42dbaC20Bf60eC34232e16408d2f745519ff2E56",
-      "startBlock": 8381746
+      "address": "0xb72FD42A94a360587dCe790947e18A2CbcD4BC65",
+      "startBlock": 22539483
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wxtm-bridge",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "scripts": {
     "codegen": "graph codegen",
     "build": "graph build",
@@ -14,5 +14,7 @@
     "@graphprotocol/graph-cli": "0.97.0",
     "@graphprotocol/graph-ts": "0.37.0"
   },
-  "devDependencies": { "matchstick-as": "0.6.0" }
+  "devDependencies": {
+    "matchstick-as": "0.6.0"
+  }
 }

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -6,11 +6,11 @@ schema:
 dataSources:
   - kind: ethereum
     name: wXTMBridge
-    network: sepolia
+    network: mainnet
     source:
-      address: "0x42dbaC20Bf60eC34232e16408d2f745519ff2E56"
+      address: "0xb72FD42A94a360587dCe790947e18A2CbcD4BC65"
       abi: wXTMBridge
-      startBlock: 8381746
+      startBlock: 22539483
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to use Ethereum mainnet instead of Sepolia, including contract address and starting block.
  - Changed license in project metadata to MIT.
  - Reformatted development dependencies for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->